### PR TITLE
Reduce cpu usage when stdin is not an tty

### DIFF
--- a/commandline.h
+++ b/commandline.h
@@ -57,6 +57,7 @@ private:
 
     std::thread m_io_thread;
     std::atomic<bool> m_shutdown { false };
+    bool m_interactive { true };
 
     mutable std::mutex m_to_write_mutex;
     std::queue<std::string> m_to_write;


### PR DESCRIPTION
On Linux ```stdin``` could be /dev/null or a pipe for example when using docker or systemd services. This leads to high cpu usage by constant reading null bytes. 
To fix this you dont need to spawn the input thread if ```isatty``` returns false.
See https://man7.org/linux/man-pages/man3/isatty.3.html  