### PR TITLE
User-defined callback for logging

### DIFF
--- a/commandline.cpp
+++ b/commandline.cpp
@@ -13,8 +13,6 @@
 #include <array>
 #endif
 
-#include <iostream>
-
 #if defined(WIN32)
 #define WINDOWS
 #elif defined(__linux) || defined(__linux__)
@@ -420,7 +418,7 @@ void Commandline::io_thread_main() {
             printf("\x1b[2K\x1b[0G%s\n%s%s\x1b[%luG", to_write.c_str(), m_prompt.c_str(), m_current_buffer.c_str(), m_prompt.size() + m_cursor_pos + 1);
             fflush(stdout);
             if (m_write_to_file) {
-                m_logfile << to_write << std::endl;
+                on_write(to_write);
             }
         }
     }
@@ -430,6 +428,9 @@ void Commandline::io_thread_main() {
         auto to_write = m_to_write.front();
         m_to_write.pop();
         printf("\x1b[2K\x1b[0G%s", to_write.c_str());
+        if (m_write_to_file) {
+            on_write(to_write);
+        }
     }
     fflush(stdout);
 }
@@ -497,10 +498,9 @@ void Commandline::clear_history() {
     m_history.clear();
 }
 
-bool Commandline::enable_write_to_file(const std::string& path) {
-    m_logfile_path = path;
-    m_logfile.open(m_logfile_path, std::ios::trunc | std::ios::out);
-    if (!m_logfile.is_open() || !m_logfile.good()) {
+bool Commandline::enable_write_to_file() {
+    if (on_write == nullptr)
+    {
         return false;
     }
     m_write_to_file = true;

--- a/commandline.cpp
+++ b/commandline.cpp
@@ -417,7 +417,7 @@ void Commandline::io_thread_main() {
             std::lock_guard<std::mutex> guard2(m_current_buffer_mutex);
             printf("\x1b[2K\x1b[0G%s\n%s%s\x1b[%luG", to_write.c_str(), m_prompt.c_str(), m_current_buffer.c_str(), m_prompt.size() + m_cursor_pos + 1);
             fflush(stdout);
-            if (m_write_to_file) {
+            if (on_write) {
                 on_write(to_write);
             }
         }
@@ -428,7 +428,7 @@ void Commandline::io_thread_main() {
         auto to_write = m_to_write.front();
         m_to_write.pop();
         printf("\x1b[2K\x1b[0G%s", to_write.c_str());
-        if (m_write_to_file) {
+        if (on_write) {
             on_write(to_write);
         }
     }
@@ -496,15 +496,6 @@ size_t Commandline::history_size() const {
 void Commandline::clear_history() {
     std::lock_guard<std::mutex> guard(m_history_mutex);
     m_history.clear();
-}
-
-bool Commandline::enable_write_to_file() {
-    if (on_write == nullptr)
-    {
-        return false;
-    }
-    m_write_to_file = true;
-    return true;
 }
 
 void Commandline::enable_key_debug() {

--- a/commandline.h
+++ b/commandline.h
@@ -39,9 +39,6 @@ public:
     }
     void set_prompt(const std::string& p);
     std::string prompt() const;
-    bool write_to_file_enabled() const { return m_write_to_file; }
-    [[nodiscard]] bool enable_write_to_file();
-    void disable_write_to_file() { m_write_to_file = false; }
 
     // key_debug writes escape-sequenced keys to stderr
     void enable_key_debug();

--- a/commandline.h
+++ b/commandline.h
@@ -9,7 +9,6 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <fstream>
 #include <functional>
 #include <limits>
 #include <mutex>
@@ -41,7 +40,7 @@ public:
     void set_prompt(const std::string& p);
     std::string prompt() const;
     bool write_to_file_enabled() const { return m_write_to_file; }
-    [[nodiscard]] bool enable_write_to_file(const std::string& path);
+    [[nodiscard]] bool enable_write_to_file();
     void disable_write_to_file() { m_write_to_file = false; }
 
     // key_debug writes escape-sequenced keys to stderr
@@ -53,6 +52,9 @@ public:
 
     // gets called when tab is pressed and new suggestions are requested
     std::function<std::vector<std::string>(Commandline&, std::string, int)> on_autocomplete { nullptr };
+
+    // Gets called if m_write_to_file is true
+    std::function<void(const std::string&)> on_write { nullptr };
 
 private:
     void io_thread_main();
@@ -89,8 +91,6 @@ private:
     std::queue<std::string> m_to_read;
     bool m_history_enabled { false };
     bool m_write_to_file { false };
-    std::ofstream m_logfile;
-    std::string m_logfile_path {};
     mutable std::mutex m_history_mutex;
     std::vector<std::string> m_history;
     std::string m_history_temp_buffer;

--- a/main.cpp
+++ b/main.cpp
@@ -29,11 +29,6 @@ int main(int argc, char** argv) {
         log_file << string_to_be_logged << '\n';
     };
 
-    if (com.enable_write_to_file() == false)
-    {
-        com.write("on_write() callback hasn't been defined!");
-    }
-
     int counter = 0;
     while (true) {
         if (com.has_command()) {

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,11 @@
+#include <fstream>
 #include "commandline.h"
 
 int main(int argc, char** argv) {
+    // Fake logging as an example
+    std::ofstream log_file("log.txt");
+    std::mutex log_mutex;
+
     Commandline com;
     // com.enable_key_debug();
     if (argc > 1) {
@@ -19,6 +24,17 @@ int main(int argc, char** argv) {
         }
     };
 
+    com.on_write = [&log_file, &log_mutex](std::string string_to_be_logged) -> void {
+        std::lock_guard<std::mutex> guard(log_mutex);
+        log_file << string_to_be_logged << '\n';
+    };
+
+    if (com.enable_write_to_file() == false)
+    {
+        com.write("on_write() callback hasn't been defined!");
+    }
+
+    int counter = 0;
     while (true) {
         if (com.has_command()) {
             auto command = com.get_command();
@@ -31,6 +47,7 @@ int main(int argc, char** argv) {
         // usually, instead of writing a message here, a message would
         // be written as the result of some internal program event.
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
-        com.write("this is a message written with com.write");
+        com.write(std::to_string(counter) + ": this is a message written with com.write");
+        counter++;
     }
 }


### PR DESCRIPTION
Logging has been replaced with the user-defined callback `on_write`.
`on_write` will only be called if defined.
Cleaned up some `#include`s.
Example added to `main.cpp`.