### PR TITLE
define VS_STARTUP_PROJECT in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,5 +22,6 @@ option(BUILD_EXAMPLES "Build example program" ON)
 if(BUILD_EXAMPLES)
     add_executable(test main.cpp)
     target_link_libraries(test commandline)
+    set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT test)
 endif()
 


### PR DESCRIPTION
With this property set, you can Ctrl+F5 to run the test app
It will launch `test` instead of attempt to launch `ALL_BUILD` as VS does by default
[screenshot](https://user-images.githubusercontent.com/37947786/161961142-154371b5-4be1-48be-8951-fa520a1e76de.png)
